### PR TITLE
Added plugin to run py.test as part of mvn install phase.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 
 			<!-- A little outdated plugin needed to import all the python
 			modules needed by pyoracc. It works using easy_install + <param>.	-->
-			<plugin>   
+			<plugin>
 				<groupId>net.sf.mavenjython</groupId>
 				<artifactId>jython-compile-maven-plugin</artifactId>
 				<version>1.3</version>
@@ -119,6 +119,29 @@
 						<phase>package</phase>
 						<goals>
 							<goal>assembly</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Run py.test as part of mvn install/mvn test -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.4.0</version>
+				<executions>
+					<execution>
+						<configuration>
+							<executable>py.test</executable>
+							<workingDirectory>python/nammu/test</workingDirectory>
+							<arguments>
+								<argument>-v</argument>
+							</arguments>
+						</configuration>
+						<id>python-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>exec</goal>
 						</goals>
 					</execution>
 				</executions>


### PR DESCRIPTION
Once merged, py.test should be run by default in current tests.